### PR TITLE
Add ulimit parameter to docker run commands in workflows

### DIFF
--- a/.github/workflows/broker-build-test.yml
+++ b/.github/workflows/broker-build-test.yml
@@ -77,6 +77,7 @@ jobs:
         run: |
           mkdir -p $HOME/solace; chmod 777 $HOME/solace
           docker run -d -p 8080:8080 -p 55555:55555 --shm-size=1g --env username_admin_globalaccesslevel=admin --env username_admin_password=admin --env system_scaling_maxkafkabridgecount="10" --name=solace \
+            --ulimit nofile=1048576:1048576 \
             --env system_scaling_maxconnectioncount="1000" --mount type=bind,source=$HOME/solace,destination=/var/lib/solace,ro=false solace/solace-pubsub-standard:latest
           while ! curl -s localhost:8080 | grep aurelia ; do sleep 1 ; done
 

--- a/.github/workflows/module-test-pipeline-main-branch-only.yml
+++ b/.github/workflows/module-test-pipeline-main-branch-only.yml
@@ -17,6 +17,7 @@ jobs:
         run: |
           mkdir -p $HOME/solace; chmod 777 $HOME/solace
           docker run -d -p 8080:8080 -p 55555:55555 --shm-size=1g --env username_admin_globalaccesslevel=admin --env username_admin_password=admin --env system_scaling_maxkafkabridgecount="10" --name=solace \
+            --ulimit nofile=1048576:1048576 \
             --env system_scaling_maxconnectioncount="1000" --mount type=bind,source=$HOME/solace,destination=/var/lib/solace,ro=false solace/solace-pubsub-standard:latest
           while ! curl -s localhost:8080 | grep aurelia ; do sleep 1 ; done
 

--- a/.github/workflows/module-test-pipeline.yml
+++ b/.github/workflows/module-test-pipeline.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           mkdir -p $HOME/solace; chmod 777 $HOME/solace
           docker run -d -p 8080:8080 -p 55555:55555 --shm-size=1g --env username_admin_globalaccesslevel=admin --env username_admin_password=admin --env system_scaling_maxkafkabridgecount="10" --name=solace \
+            --ulimit nofile=1048576:1048576 \
             --env system_scaling_maxconnectioncount="1000" --mount type=bind,source=$HOME/solace,destination=/var/lib/solace,ro=false solace/solace-pubsub-standard:latest
           while ! curl -s localhost:8080 | grep aurelia ; do sleep 1 ; done
 

--- a/.github/workflows/prep-internal-release.yml
+++ b/.github/workflows/prep-internal-release.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           mkdir -p $HOME/solace; chmod 777 $HOME/solace
           docker run -d -p 8080:8080 -p 55555:55555 --shm-size=1g --env username_admin_globalaccesslevel=admin --env username_admin_password=admin --env system_scaling_maxkafkabridgecount="10" --name=solace \
+            --ulimit nofile=1048576:1048576 \
             --env system_scaling_maxconnectioncount="1000" --mount type=bind,source=$HOME/solace,destination=/var/lib/solace,ro=false solace/solace-pubsub-standard:latest
           while ! curl -s localhost:8080 | grep aurelia ; do sleep 1 ; done
 

--- a/.github/workflows/verify-registry-release.yml
+++ b/.github/workflows/verify-registry-release.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           mkdir -p $HOME/solace; chmod 777 $HOME/solace
           docker run -d -p 8080:8080 -p 55555:55555 --shm-size=1g --env username_admin_globalaccesslevel=admin --env username_admin_password=admin --env system_scaling_maxkafkabridgecount="10" --name=solace \
+            --ulimit nofile=1048576:1048576 \
             --env system_scaling_maxconnectioncount="1000" --mount type=bind,source=$HOME/solace,destination=/var/lib/solace,ro=false solace/solace-pubsub-standard:"10.6.1.52"
           while ! curl -s localhost:8080 | grep aurelia ; do sleep 1 ; done
 


### PR DESCRIPTION
## Summary
- Added --ulimit nofile=1048576:1048576 to all docker run commands
- This increases the file descriptor limit for Solace broker containers
- Applied to all workflow files containing docker run commands

## Details
This change adds the ulimit parameter to configure the maximum number of open file descriptors for the Solace broker containers in our GitHub Actions workflows. The increased limit (1048576) ensures the broker can handle higher loads and prevents potential issues related to file descriptor exhaustion.

🤖 Generated with Claude Code